### PR TITLE
build: add password-assistant repo to config

### DIFF
--- a/config/global-repos.list
+++ b/config/global-repos.list
@@ -26,3 +26,4 @@ blindnet-io/blindsend-fe
 blindnet-io/blindsend-be
 blindnet-io/blindsend-server
 blindnet-io/blindsend
+blindnet-io/password-assistant


### PR DESCRIPTION
The script has been already run to add the globals labels to this new repo.
I also added the Q3 2022 milestone (prep Q3 isn't necessary).
